### PR TITLE
Add data file

### DIFF
--- a/src/data/summits.json
+++ b/src/data/summits.json
@@ -1,0 +1,18 @@
+{
+  "peaks": [
+    {
+      "name": "Grand Teton",
+      "slug": "grand-teton",
+      "elevation": 13775,
+      "lat": 43.742726,
+      "lng": -110.802585
+    },
+    {
+      "name": "South Teton",
+      "slug": "south-teton",
+      "elevation": 12513,
+      "lat": 43.719459,
+      "lng": -110.819026
+    }
+  ]
+}


### PR DESCRIPTION
Adds starter data for summit peaks, in JSON format, with the following structure:

- `name`: human-readable name
- `slug`: Unique ID for each peak (that’s also human readable-ish)
- `elevation`: Elevation, in feet. Left as a JavaScript `Number` so we can perform Maths™ on it
- `lat`: latitude, expressed as a `Float`, also for the purposes of doing Maths™
- `lng`: longitude

I was able to retrieve these easily from Google Maps by right-clicking on a peak and selecting “What’s here?”—the lat/lng shows up. The elevations I grabbed from Wikipedia.

This is just the start; we’ll add several more before we place them on a map.